### PR TITLE
fix: stay with paho-mqtt 1.x due to breaking change in 2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ include = [
 
 [tool.poetry.dependencies]
 python = ">=3.7.2, <4.0.0"
-paho-mqtt = ">=1.5.0"
+paho-mqtt = ">=1.5.0, <2.0.0"
 dash = ">=2.9.0, <3.0.0"
 dash-daq = "^0.5.0"
 plotly = ">=5"


### PR DESCRIPTION
Hi @0x3dlux, as mentioned in https://github.com/flobz/psa_car_controller/issues/733#issuecomment-1947226989, as many people are currently using your fork, you might want to consider to include this workaround preventing a crash on new install. See also https://github.com/flobz/psa_car_controller/issues/759.

This fixes psacc crashing with:
TypeError: Client.__init__() missing 1 required positional argument: 'callback_api_version'

paho-mqtt 2.0, released on Feb, 10th, requires additional arguments to mqtt.Client(), see
https://github.com/eclipse/paho.mqtt.python/blob/v2.0.0/docs/migrations.rst. So stay with 1.x for now.